### PR TITLE
More compatible panic statement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ fn build_text(filename: Option<String>) -> Select<Recorded<Text>> {
         Some(name) => {
             match Text::open_file(name) {
                 Ok(v) => v,
-                Err(e) => panic!(e.to_string()),
+                Err(e) => panic!("{}", e),
             }
         }
         None => Text::empty(),


### PR DESCRIPTION
On Redox, strings cannot be passed to panic!, as it accepts the same arguments of format! and println!

This fixes compilation on Redox, while still allowing compilation on other platforms