### PR TITLE
Update README with cargo install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 Smith is a simple terminal-based text editor written in Rust.
 
+## Install
+
+Using Cargo:
+```
+cargo install smith
+```
+
 ## Features
 
 * line numbers


### PR DESCRIPTION
Added section in README specifying how to install smith using cargo.