### PR TITLE
Remove the Command struct

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -16,24 +16,15 @@ pub enum State {
     Selected,
 }
 
-pub struct Command {
-    state: State,
-}
-
 const SCROLL_FACTOR: usize = 2;
 
-impl Command {
-    pub fn new() -> Command {
-        Command {
-            state: State::Insert,
-        }
-    }
-
-    pub fn treat_event<T>(&mut self, content: &mut T, view: &mut View, event: Event) -> bool
+impl State {
+    // Handles a Termion event, consuming the current state and returning the new state
+    pub fn treat_event<T>(self, content: &mut T, view: &mut View, event: Event) -> Self
     where
         T: Editable + Saveable + Undoable + Selectable,
     {
-        self.state = match self.state.clone() {
+        match self {
             State::Prompt(prompt, message) => {
                 treat_prompt_event(content, view, event, prompt, message)
             }
@@ -42,11 +33,6 @@ impl Command {
             State::Message => treat_message_event(content, view, event),
             State::Selected => treat_selected_event(content, view, event),
             State::Exit => panic!("continued after an Exit state"),
-        };
-        if let State::Exit = self.state {
-            true
-        } else {
-            false
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ mod command;
 mod state;
 mod view;
 
-use command::Command;
+use command::State;
 use state::{Recorded, Select, Text};
 use std::env;
 use std::io::stdin;
@@ -32,7 +32,7 @@ fn main() {
 fn edit_file(filename: Option<String>) {
     let mut text = build_text(filename);
     let mut view = View::new();
-    let mut command = Command::new();
+    let mut state = State::Insert;
 
     let stdin = stdin();
 
@@ -41,8 +41,9 @@ fn edit_file(filename: Option<String>) {
     let mut events = stdin.events();
     loop {
         if let Some(event) = events.next() {
-            if command.treat_event(&mut text, &mut view, event.unwrap()) {
-                break;
+            state = match state.treat_event(&mut text, &mut view, event.unwrap()) {
+                State::Exit => break,
+                other => other,
             }
         }
         view.render(&text);


### PR DESCRIPTION
It's unnecessary, since it only contains a `State`.
This makes handling of exits more concise and eliminates the need for cloning.